### PR TITLE
Fix form submit button color issue

### DIFF
--- a/components/AvailableForm.jsx
+++ b/components/AvailableForm.jsx
@@ -17,10 +17,12 @@ const Form = ({ title, text, border, background }) => {
       <div className={`${background} w-full rounded-t-3xl h-2/3`}>
         <p className="text-center p-2 font-bold text-lg">{title}</p>
       </div>
-      <div className="bg-acm-black w-full flex justify-center items-center flex-col h-1/3 rounded-b-3xl">
+      <div
+        className={`bg-acm-black w-full flex justify-center items-center flex-col h-1/3 rounded-b-3xl`}
+      >
         <button
           onClick={onClick}
-          className={`${text} text-center ${border} border-2 p-1 rounded-full m-0 w-11/12 font-semibold text-xl cursor-pointer hover:text-acm-black hover:${background}`}
+          className={`${text} text-center ${border} border-2 p-1 rounded-full m-0 w-11/12 font-semibold text-xl cursor-pointer hover:text-acm-black hover:bg-acm-marine hover:bg-acm-orange hover:!${background}`}
         >
           apply
         </button>

--- a/components/CompletedForm.jsx
+++ b/components/CompletedForm.jsx
@@ -23,7 +23,7 @@ const Form = ({ title, text, border, background }) => {
       >
         <button
           onClick={onClick}
-          className={`text-acm-black text-center border-acm-black border-2 p-1 rounded-full m-0 w-11/12 font-semibold text-xl cursor-pointer hover:bg-acm-black hover:${text}`}
+          className={`text-acm-black text-center border-acm-black border-2 p-1 rounded-full m-0 w-11/12 font-semibold text-xl cursor-pointer hover:bg-acm-black hover:text-acm-marine hover:text-acm-orange hover:!${text}`}
         >
           details
         </button>


### PR DESCRIPTION
There's a strange issue where hover won't work with colors passed from props; my workaround is preloading the colors and then using the important modifier to specify that I want the prop color instead. 
<img width="440" alt="image" src="https://user-images.githubusercontent.com/90938120/208039498-f5e2a317-9ac8-4fed-9e2d-57ac0d29dec1.png"> 

I'm kind of stumped as to how to make this more dynamic, lmk if there is a more efficient fix

<img width="399" alt="Screen Shot 2022-12-15 at 22 34 56" src="https://user-images.githubusercontent.com/90938120/208038667-dfa045ce-2c9e-4791-83f4-4071688fd826.png">
<img width="193" alt="Screen Shot 2022-12-15 at 22 35 00" src="https://user-images.githubusercontent.com/90938120/208038671-1db46513-4110-45c4-b6d0-7d6a85c73ebd.png">
<img width="201" alt="Screen Shot 2022-12-15 at 22 35 03" src="https://user-images.githubusercontent.com/90938120/208038673-e3bc6e79-3d12-4764-90bd-c7d2f6830a7e.png">


<img width="403" alt="Screen Shot 2022-12-15 at 22 34 31" src="https://user-images.githubusercontent.com/90938120/208040069-79958607-facd-4ccf-8965-799a7c226169.png">
<img width="221" alt="Screen Shot 2022-12-15 at 19 33 58" src="https://user-images.githubusercontent.com/90938120/208040090-bd426615-0a37-478b-aa1d-345df26ed3f9.png">
<img width="226" alt="Screen Shot 2022-12-15 at 19 34 14" src="https://user-images.githubusercontent.com/90938120/208040094-4fdaeee0-a163-458d-9537-46b2bfcf0991.png">


