### PR TITLE
Adjust spacing on user profile page

### DIFF
--- a/components/Profile.jsx
+++ b/components/Profile.jsx
@@ -223,23 +223,17 @@ const Profile = ({ name, major, year, netId, email, points }) => {
           <p className="text-acm-black text-3xl font-lexend font-bold">
             netid:
           </p>
-          <p className="text-acm-black text-2xl font-lexend">
-            {netId}
-          </p>
+          <p className="text-acm-black text-2xl font-lexend">{netId}</p>
 
           <p className="text-acm-black text-3xl font-lexend font-bold pt-3">
             email:
           </p>
-          <p className="text-acm-black text-2xl font-lexend">
-            {email}
-          </p>
+          <p className="text-acm-black text-2xl font-lexend">{email}</p>
 
           <p className="text-acm-black text-3xl font-lexend font-bold pt-3">
             points:
           </p>
-          <p className="text-acm-black text-2xl font-lexend">
-            {points}
-          </p>
+          <p className="text-acm-black text-2xl font-lexend">{points}</p>
         </Col>
         <Col xl={12} className="sm:text-left">
           <button

--- a/components/Profile.jsx
+++ b/components/Profile.jsx
@@ -200,8 +200,8 @@ const Profile = ({ name, major, year, netId, email, points }) => {
     );
   } else {
     return (
-      <Row className="w-full">
-        <Col xl={6}>
+      <Row className="w-full text-center">
+        <Col xl={6} className="sm:text-left">
           <p className="text-acm-black text-3xl font-lexend font-bold pb-1">
             name:
           </p>
@@ -219,29 +219,29 @@ const Profile = ({ name, major, year, netId, email, points }) => {
           </p>
           <p className="text-acm-black text-2xl font-lexend">{user.year}</p>
         </Col>
-        <Col xl={6}>
-          <p className="text-acm-black text-3xl font-lexend h-fit w-fit font-bold">
+        <Col xl={6} className="sm:text-left">
+          <p className="text-acm-black text-3xl font-lexend font-bold">
             netid:
           </p>
-          <p className="text-acm-black text-2xl font-lexend h-fit w-fit">
+          <p className="text-acm-black text-2xl font-lexend">
             {netId}
           </p>
 
-          <p className="text-acm-black text-3xl font-lexend h-fit w-fit font-bold pt-3">
+          <p className="text-acm-black text-3xl font-lexend font-bold pt-3">
             email:
           </p>
-          <p className="text-acm-black text-2xl font-lexend h-fit w-fit">
+          <p className="text-acm-black text-2xl font-lexend">
             {email}
           </p>
 
-          <p className="text-acm-black text-3xl font-lexend h-fit w-fit font-bold pt-3">
+          <p className="text-acm-black text-3xl font-lexend font-bold pt-3">
             points:
           </p>
-          <p className="text-acm-black text-2xl font-lexend h-fit w-fit">
+          <p className="text-acm-black text-2xl font-lexend">
             {points}
           </p>
         </Col>
-        <Col xl={12}>
+        <Col xl={12} className="sm:text-left">
           <button
             id="editProfile"
             className=" w-full sm:w-4/6 md:w-5/12 py-2 font-lexend font-bold text-acm-black border-2 border-acm-lightpurple text-2xl transition-colors duration-150 bg-acm-lightpurple rounded-lg focus:shadow-outline hover:border-acm-black"

--- a/pages/user/profile.js
+++ b/pages/user/profile.js
@@ -28,7 +28,7 @@ const ProfilePage = () => {
     <div className="flex justify-center pt-[14vh]">
       <Row className="w-11/12">
         <Header title="profile" color="acm-green" />
-        <Col className="flex justify-center items-stretch m-0 p-0">
+        <Col className="flex justify-center items-stretch ml-0 mt-0 mr-0 mb-8 p-0">
           <Photo email={data?.id} />
         </Col>
         <Col>


### PR DESCRIPTION
I know the issue was geared more towards mobile responsiveness, but I noticed that the larger screen sizes also had some spacing inconsistencies so I let my changes affect all screen sizes. I can revert those if needed

<img width="221" alt="Screen Shot 2022-12-17 at 20 39 53" src="https://user-images.githubusercontent.com/90938120/208282035-027ae289-4c27-4ce9-823e-a447acb427d5.png">
<img width="220" alt="Screen Shot 2022-12-17 at 20 39 56" src="https://user-images.githubusercontent.com/90938120/208282038-dfa964c1-4b77-4f18-83f9-c5d7b5090633.png">


<img width="1218" alt="Screen Shot 2022-12-17 at 20 40 28" src="https://user-images.githubusercontent.com/90938120/208282040-a20c5a5e-906e-438f-9475-6c5fe6ce8c46.png">
<img width="333" alt="Screen Shot 2022-12-17 at 20 40 17" src="https://user-images.githubusercontent.com/90938120/208282041-063f13ff-55b6-43f8-bfa8-1abe9cbbe5cd.png">
