### PR TITLE
Spacing Fixes, Issues #425 and #427

### DIFF
--- a/components/CardAccess.jsx
+++ b/components/CardAccess.jsx
@@ -51,7 +51,7 @@ export default function CardAccess() {
       });
   };
   return (
-    <div className=" h-60 flex justify-center items-center flex-col w-full">
+    <div className="h-40 flex justify-center items-center flex-col w-full">
       <p className="text-xl lg:text-3xl font-lexend">
         Please enter the number at the bottom right of your R'Card
       </p>

--- a/components/Clubroom.jsx
+++ b/components/Clubroom.jsx
@@ -5,7 +5,7 @@ import Frame from "./Frame";
 
 const Clubroom = () => {
   return (
-    <div className="flex justify-center flex-col font-lexend text-acm-black mx-auto w-11/12 h-screen">
+    <div className="flex justify-center flex-col font-lexend text-acm-black mx-auto w-11/12 h-auto">
       <Row className="flex items-center rounded-2xl !p-4 m-0 pb-8">
         <Col sm={6} className="text-text w-full h-full p-4 text-2xl ">
           <p>

--- a/components/ResumeFeedback.jsx
+++ b/components/ResumeFeedback.jsx
@@ -9,7 +9,7 @@ const ResumeFeedback = () => {
         feedback
       </p>
       <p className="text-acm-black text-xl font-lexend m-0 pb-1">formatting</p>
-      <div className="flex w-11/12 flex-grow flex-col border-2 border-acm-black">
+      <div className="flex w-full flex-grow flex-col border-2 border-acm-black">
         {feedbackList.map((feedback, index) => (
           <li
             key={index}

--- a/components/ResumeUpload.jsx
+++ b/components/ResumeUpload.jsx
@@ -40,7 +40,7 @@ const ResumeUpload = ({ setResume, resume }) => {
         </p>
         <input
           placeholder="resume link"
-          className="w-11/12 border-black border-2 py-2 rounded-xl px-4 text-xl font-lexend"
+          className="w-full border-black border-2 py-2 rounded-xl px-4 text-xl font-lexend"
           onChange={handleResumeLinkChange}
           type="text"
         />

--- a/pages/resume.js
+++ b/pages/resume.js
@@ -21,12 +21,12 @@ const ResumePage = () => {
 
       <title>Resume</title>
 
-      <div className="pt-3 flex w-11/12 h-full pb-1">
-        <div className="w-2/3 gap-3 flex flex-col">
+      <div className="pt-3  flex w-11/12 h-full pb-1">
+        <div className="w-3/5 flex flex-col">
           <ResumeUpload setResume={setResume} resume={resume} />
           <ResumeFeedback />
         </div>
-        <div className="w-1/3">
+        <div className="w-2/5">
           <PDFViewer pdf={resume} />
         </div>
       </div>


### PR DESCRIPTION
Closes #425, closes #427 
For Clubroom, changed height parameters in both clubroom and cardaccess to not occupy so much whitespace.
For Resume,  shifted textboxes from 11/12 to full, then shifted partitioning to make the PDF viewer have more space.